### PR TITLE
docs: update 404 link zk-SNARKs.md

### DIFF
--- a/Blockchain/zk-SNARKs.md
+++ b/Blockchain/zk-SNARKs.md
@@ -124,4 +124,4 @@ description: ZK-SNARKs is a type of zero-knowledge proof that allows one party t
 
 - https://consensys.net/blog/developers/introduction-to-zk-snarks/
 - https://ethereum.org/en/developers/docs/scaling/zk-rollups/
-- https://vitalik.ca/general/2022/06/15/using_snarks.html
+- https://vitalik.eth.limo/general/2022/06/15/using_snarks.html


### PR DESCRIPTION
Hi! I fixes a dead link in the `zk-SNARKs.md` file. The old link pointed to a deprecated or non-existent page for Vitalik Buterin's blog post on using SNARKs. It has been updated to the correct and current URL.