### PR TITLE
docs: Fixed grammatical error in the sentence structure

### DIFF
--- a/Blockchain/ton_blockchain_of_blockchains.md
+++ b/Blockchain/ton_blockchain_of_blockchains.md
@@ -12,7 +12,7 @@ authors:
 
 TON (The Open Network) is a blockchain platform originally developed by the team behind Telegram Messenger. By taking advantage of unique sharding technology, Multi-blockchain architecture and Instant Hypercube Routing protocol, TON aims to enable fast transactions and smart contracts with a high level of scalability and security.
 
-To understand what actually happen under these shiny names of technologies, this post will dissect one by one in the simplest way.
+To understand what actually happens under these shiny names of technologies, this post will dissect one by one in the simplest way.
 
 ## Actor model, Everything is a Smart Contract
 


### PR DESCRIPTION
I’ve corrected a small grammatical mistake in the text. The sentence now reads "To understand what actually happens under these shiny names of technologies" instead of "happen."
The issue was that the verb "happen" should be in the third-person singular form "happens." 