### PR TITLE
docs: Fixed Minor Typos and Grammar Issues Across Multiple Files

### DIFF
--- a/Zettelkasten/How to Take Smart Notes/Brainstorming surfaces available ideas, not new ideas.md
+++ b/Zettelkasten/How to Take Smart Notes/Brainstorming surfaces available ideas, not new ideas.md
@@ -1,6 +1,6 @@
 Brainstorming is a common suggestion whenever anyone is hunting for ideas. But brainstorming doesn't generate new thinking; it can only bring forward existing, readily available ideas. And it brings them up in their raw, unprocessed form. These aren't necessarily our best ideas. They're just the ones that are top of mind. They may not represent our own, original thought, or the idea best suited to the problem at hand; they're just what's most available to us.
 
-That's dangerous. As human beings, we're attached to our ideas—our first ideas, especially. We're loathe to move past them. The hold us back like anchors, preventing us from looking at them critically. And so, upon brainstorming, we may invest in available ideas and close ourselves off from disconfirming evidence.
+That's dangerous. As human beings, we're attached to our ideas—our first ideas, especially. We're loathe to move past them. They hold us back like anchors, preventing us from looking at them critically. And so, upon brainstorming, we may invest in available ideas and close ourselves off from disconfirming evidence.
 
 What's more, researchers have consistently found that brainstorming does not help us generate an abundance of ideas; rather, people come up with fewer ideas and cover a narrower range of topics than individuals do by themselves.
 

--- a/Zettelkasten/How to Take Smart Notes/Decontextualize ideas to make them new.md
+++ b/Zettelkasten/How to Take Smart Notes/Decontextualize ideas to make them new.md
@@ -15,7 +15,7 @@ Some examples of ways we do this:
 -   In Modernist theatre, playwrights like Bertolt Brecht sought to render strange the familiar patterns, structure, and conventions that we take for granted, making it impossible for us to identify with the characters on stage. Just as Brecht exposed the fictive qualities of his characters and their stories, we strive to recognize that our own ideas are never natural but the product of past thinking and its paradigms.
 -   Tiago Forte (2018) argues that in order to expose and disrupt our assumptions, we must continually disassociate ideas from their context. For Forte, overcoming our own paradigms of thought is the final bottleneck in critical thinking.
 -   We can think, as well, of design thinking concepts like "reframing the problem" or "depatterning." This, too, revolves around the belief that we can make more effective decisions by creating processes and structures that force us to treat situations as novel. This can help overturn our brain's reliance on heuristics.
--   In _Drawing on the Right Side of the Brain_, there's an exercise in which you turn an image upside-down. This helps break the system of symbols that we rely on to draw things that are familiar to us (e.g. features of a face) and focus instead on its shape and its contours as they actual appear, rather than as we have internalized them.
+-   In _Drawing on the Right Side of the Brain_, there's an exercise in which you turn an image upside-down. This helps break the system of symbols that we rely on to draw things that are familiar to us (e.g. features of a face) and focus instead on its shape and its contours as they actually appear, rather than as we have internalized them.
 
 ---
 

--- a/Zettelkasten/How to Take Smart Notes/Design environments to facilitate behaviours.md
+++ b/Zettelkasten/How to Take Smart Notes/Design environments to facilitate behaviours.md
@@ -1,6 +1,6 @@
 
 
-Willpower is a finite resource, and difficult to sustain. Designing environments to facilitate desire behaviour is a much more effective approach in the long run.
+Willpower is a finite resource, and difficult to sustain. Designing environments to facilitate desired behaviour is a much more effective approach in the long run.
 
 A well-designed environment demands less of our limited mental resources, enabling us to better focus resources where they will deliver the most impact. As well, the right environment can nudge us toward virtuous activity without forcing us to become virtuous.
 


### PR DESCRIPTION
I’ve corrected a few minor typos and grammar issues in the following files:

- In *`Brainstorming surfaces available ideas, not new ideas.md`*, I fixed "The hold us back like anchors" to "They hold us back like anchors".
- In *`Decontextualize ideas to make them new.md`*, I changed "as they actual appear" to "as they actually appear".
- In *`Design environments to facilitate behaviours.md`*, I updated "Designing environments to facilitate desire behaviour" to "Designing environments to facilitate desired behaviour".

These changes should improve readability and clarity.