### PR TITLE
docs: Fixed incorrect link to "inert" article

### DIFF
--- a/Frontend/HTML inert.md
+++ b/Frontend/HTML inert.md
@@ -35,5 +35,5 @@ The born of `inert` helps to eliminate the need for [[Focus trap | focus trap]] 
 
 #### References
 
-- https://developer.chrome.com/articles/inert/
+- https://web.dev/articles/inert
 - https://patrickhlauke.github.io/aria/demos/modal/index-aria-inert.html


### PR DESCRIPTION
I’ve updated the link to the "inert" HTML attribute documentation.
The original link to developer.chrome.com was outdated, so I’ve replaced it with the correct one from web.dev.
Everything else remains unchanged.