### PR TITLE
docs: typo fix

### DIFF
--- a/UX Research/Four Theories of Truth.md
+++ b/UX Research/Four Theories of Truth.md
@@ -3,7 +3,7 @@ In epistemology, there are generally four theories by which a claim may be evalu
 1.  The correspondence theory of truth: a claim is true if it conforms to observable nature
 2.  The coherence theory of truth: a claim is true if it is logically coherent
 3.  The consensus theory of truth: a claim is true if it conforms to the general consensus on the matter
-4.  The pragmatic theory of truth: a claim is true if it it is useful or otherwise beneficial to believe in it
+4.  The pragmatic theory of truth: a claim is true if it is useful or otherwise beneficial to believe in it
 
 Understanding each of these methods provides a rubric by which a claim can be evaluated. Weighing the claim against each model in turn can help facilitate critical thought.
 


### PR DESCRIPTION
There's a small typo:

- **"it it is useful"** → corrected to **"it is useful"** (extra "it").
