### PR TITLE
docs: fix typo in "flicker of white background"

### DIFF
--- a/Frontend/Dark mode flickers a white background for a fraction of a second.md
+++ b/Frontend/Dark mode flickers a white background for a fraction of a second.md
@@ -5,7 +5,7 @@ tags:
  - dark-mode
 authors: 
  - thanh
-description: The dark mode feature uses local storage to store a user's preference for future usage. The problem is that when the dark mode is enabled and the page is reloaded, there's a flicker of white background all over the page before it turns dark. This happens for a fraction of a second and doesn't look natural.
+description: The dark mode feature uses local storage to store a user's preference for future usage. The problem is that when the dark mode is enabled and the page is reloaded, there's a flicker of a white background all over the page before it turns dark. This happens for a fraction of a second and doesn't look natural.
 title: Dark mode flickers a white background for a fraction of a second
 github_id: zlatanpham
 date: 2022-08-11


### PR DESCRIPTION
#### What's this PR do?

I noticed a small typo in the phrase "flicker of white background". It should be "flicker of a white background" to make the sentence grammatically correct. I've updated it accordingly.
