### PR TITLE
docs: Fixed grammatical issues in docs

### DIFF
--- a/01_literature/Writing/Question tree.md
+++ b/01_literature/Writing/Question tree.md
@@ -8,7 +8,7 @@ date: 2022-04-18
 ## What is a question tree?
 The purpose of a question tree is to brainstorm questions and identify research approaches to gather content about the client’s problem space. The idea is to generate a tree outline of important and miscellaneous questions regarding the problem to explore what business domains and which stakeholders to ask in order to answer our questions.
 
-In consulting, this eventually leads into a decision tree to decide critical business decisions, in which may be presented in a deliverable. Question trees can serve as a pre-process step for decision trees, as it helps more in the research process to allow better evaluation of business decisions.
+In consulting, this eventually leads into a decision tree to decide critical business decisions, which may be presented in a deliverable. Question trees can serve as a pre-process step for decision trees, as it helps more in the research process to allow better evaluation of business decisions.
 
 ### What’s the difference between a question tree and a decision tree?
 Decision trees hold polar questions, meaning they mainly branch with yes or no answers. Question trees hold content questions in which are interrogative by nature and elicit specific answers much broader than yes or no.

--- a/01_literature/Writing/The Six Lines of Gold.md
+++ b/01_literature/Writing/The Six Lines of Gold.md
@@ -23,7 +23,7 @@ There may be intonation or inflections that are needed for certain punctuation, 
 
 > How similar is it to languages I already understand? What will help and what will interfere? (Will acquisition erase a previous language? Can I borrow structures without fatal interference like Portuguese after Spanish?)
 
-The idea of finding similarities is to also help acquire fluency faster while also identifying what key differences that should we look out for.
+The idea of finding similarities is to also help acquire fluency faster while also identifying what the key differences that we should look out for.
 
 > All of which answer: How difficult will it be, and how long would it take to become functionally fluent?
 

--- a/01_literature/Writing/state-explain-link.md
+++ b/01_literature/Writing/state-explain-link.md
@@ -14,7 +14,7 @@ State, explain, link is a basic style for organizing and explaining ideas in an 
 
 | Notions | Coverage | Description                                           |
 | ------- | -------- | ----------------------------------------------------- |
-| State   | breadth  | introduce briefly about what the paragraph will cover |
+| State   | breadth  | introduce briefly what the paragraph will cover       |
 | Explain | depth    | go into depth about what you want to cover            |
 | Link    | relation | link a related item such as giving an example         |
 


### PR DESCRIPTION
#### What's this PR do?

I’ve made some small but important grammar corrections across a couple of files:

- In `01_literature/Writing/state-explain-link.md`, I replaced "in which" with "which" to ensure proper sentence structure.
- In `01_literature/Writing/The Six Lines of Gold.md`, I corrected "the key differences that should we look out for" to "the key differences that we should look out for."
- In `01_literature/Writing/state-explain-link.md`, I removed the extra "about" in the phrase "introduce briefly about what the paragraph will cover," making it "introduce briefly what the paragraph will cover."

These changes should help the text read more smoothly and accurately.