### PR TITLE
docs: fix typo in the UX research methods section

### DIFF
--- a/UX Research/Landscape of UX research methods.md
+++ b/UX Research/Landscape of UX research methods.md
@@ -14,7 +14,7 @@ Attitudinal research uncovers what people say, or their stated beliefs; behaviou
 
 ## Qualitative vs quantitative
 
-Qualitative data-gathering generally involves direct observation of the subject, whereas quantitative data-gathering gathers information indirectly through measurement, analytics, or surveys. In general, qualitative methods are used to answer questions of why or how; quantitative method are used to uncover how many or how much.
+Qualitative data-gathering generally involves direct observation of the subject, whereas quantitative data-gathering gathers information indirectly through measurement, analytics, or surveys. In general, qualitative methods are used to answer questions of why or how; quantitative methods are used to uncover how many or how much.
 
 ## Context of use
 


### PR DESCRIPTION
#### What's this PR do?

I noticed a small typo in the section about UX research methods. The phrase "quantitative method are used" was corrected to "quantitative methods are used" to match the plural form. 