### PR TITLE
fix: katex format

### DIFF
--- a/AI/Building LLM system/quantization-in-llm.md
+++ b/AI/Building LLM system/quantization-in-llm.md
@@ -48,7 +48,9 @@ In this part, we focus on the asymmetric mode.
 
 The fundamental formula is:
 
-$$q = round(s * w + z)$$
+$$
+q = round(s * w + z)
+$$
 
 where:
 
@@ -73,31 +75,47 @@ The process maps values from higher to lower precision (e.g., `FP32` to `INT8`).
 
 2. **Scale factor calculation**: Scaling factor represent for 1 unit of the original value, how many units of the quantized value it corresponds to.
 
-$$s = \frac{q_{max} - q_{min}}{w_{max} - w_{min}}$$
+$$
+s = \frac{q_{max} - q_{min}}{w_{max} - w_{min}}
+$$
 
 Example calculation:
-$$s = \frac{127-(-128)}{12.654-(-24.43)} = 6.8763$$
+$$
+s = \frac{127-(-128)}{12.654-(-24.43)} = 6.8763
+$$
 
 3. **Zero point calculation**: Zero point is the value that corresponds to the original value of 0.0 in the quantized value range.
 
-$$z = q_{min} - round(s * w_{min})$$
+$$
+z = q_{min} - round(s * w_{min})
+$$
 
 Example calculation:
-$$z = -128 - round(6.8763 * (-24.43)) = 40$$
+$$
+z = -128 - round(6.8763 * (-24.43)) = 40
+$$
 
 1. **Quantization application**:
 
-$$q = round(s * w + z)$$
+$$
+q = round(s * w + z)
+$$
 
 Resulting values:
-$$q = [-128, -100, 41, 86]$$
+$$
+q = [-128, -100, 41, 86]
+$$
 
 5. **De-quantization process**:
 
-$$w = \frac{q - z}{s}$$
+$$
+w = \frac{q - z}{s}
+$$
 
 To reproduce the 1st original value:
-$$w = \frac{-128 - 40}{6.8763} = -24.431743$$
+$$
+w = \frac{-128 - 40}{6.8763} = -24.431743
+$$
 
 You can see there is some difference between the original value and the de-quantized value. This is called **quantization error**. The quantization error is a result of the fact that we are mapping a continuous range of values to a discrete range of values. The quantization error is usually small and can be ignored in most cases. However, it can accumulate over time and cause a significant error in the final result. To minimize the quantization error, we can use a larger quantized range or a higher precision.
 

--- a/Blockchain/Liquidity pool.md
+++ b/Blockchain/Liquidity pool.md
@@ -22,19 +22,31 @@ The process could be illustrated by the picture below:
 
 Liquidity pools form the backbone of DEX by applying the automated market maker (AMM) system. Here’s the main formula that mathematically determines what the market price of the token in the pool should be:
 
-$$ x\*y=k $$
+$$ 
+x * y = k 
+$$
 
-x and y represent the respective token balance of a pairing and **k is a constant that will never change**.
+Where x and y represent the respective token balance of a pairing and **k is a constant that will never change**.
 
-Let’s use the ETH-DAI pair as an example, with 10 ETH and 1,000 DAI in the liquidity pool. What happens when someone wants to buy 1 ETH from this pool? How much does he need to pay?
+Let's use the ETH-DAI pair as an example, with 10 ETH and 1,000 DAI in the liquidity pool. What happens when someone wants to buy 1 ETH from this pool? How much does he need to pay?
 
 The k constant is 10,000 since there are 10 ETH and 1,000 DAI.
 
-$$ 10 ETH \* 1,000 DAI = 10,000 $$
+$$ 
+10 \text{ ETH} * 1,000 \text{ DAI} = 10,000 
+$$
 
 If the buyer withdraws 1 ETH, he has to deposit some DAI into the pool so that k remains constant.
 
-$$ (10 - 1) ETH \* (1,000 - y) = 10,000$$$$1,000 - y = 10,000/(10-1)$$$$y = 111.11 $$
+$$ 
+(10 - 1) \text{ ETH} * (1,000 - y) = 10,000 
+$$
+$$ 
+1,000 - y =\frac{10000}{10 - 1} 
+$$
+$$
+ y = 111.11 
+$$
 
 And because we have no limit orders in AMM, the smart contract would automatically compute y to determine the price to pay and that is approximately 111.11 DAI.
 
@@ -78,16 +90,33 @@ Suppose the price of ETH in our LP is $100. What if the price of ETH on Coinbase
 
 Let’s use a pool that has 100 ETH and 10,000 DAI. The relation between x, y, k, and ETH price could be shown by:
 
-$$ x _ y = k$$$$x = ETH\ price _ y $$
+$$ 
+x * y = k 
+$$
+$$
+x = \frac{k}{\text{ETH price}} 
+$$
 
 We could easily calculate x and y by k and ETH price:
 
-$$ x = \sqrt{k \over ETH\ price}$$
-$$y = \sqrt{k \* ETH\ price} $$
+$$ 
+x = \sqrt{\frac{k}{\text{ETH price}}} 
+$$
+$$ 
+y = \sqrt{k * \text{ETH price}} 
+$$
 
 Assume someone supplies 1 ETH and 100 DAI into the pool. How much ETH and DAI he could get back if the ETH price pumps to $120?
 
-$$ k = 100 _ 10,000 = 1,000,000 $$$$x = \sqrt{1,000,000 \over 120} = 91.29$$$$y = \sqrt{1,000,000 _ 120} = 10,954.45 $$
+$$ 
+k = 100 * 10,000 = 1,000,000 
+$$
+$$ 
+x = \sqrt{\frac{1,000,000}{120}} = 91.29 
+$$
+$$ 
+y = \sqrt{1,000,000 * 120} = 10,954.45 
+$$
 
 Since his share in the pool is 1%, the LP gets back 0.9129 ETH and 109.5445 DAI if he wants to withdraw his stake in the pool. The total value of his stake would be 0.9129 ETH \* $120 + $109.54, which totals up to be $219.09.
 


### PR DESCRIPTION
Gohugo KaTeX formatting differs slightly from standard KaTeX. As we migrate to Next.js, we need to adjust the math formatting to ensure compatibility.

- PR handle Katex: https://github.com/dwarvesf/memo.d.foundation/pull/79
- PR migrate nextjs: https://github.com/dwarvesf/memo.d.foundation/pull/39