### PR TITLE
Fix dead neptune.ai LLM observability link

### DIFF
--- a/topics/llm/logs-pillar.md
+++ b/topics/llm/logs-pillar.md
@@ -127,7 +127,7 @@ While logging might feel like a small detail in the bigger picture of generative
 ## References
 
 - https://www.honeyhive.ai/monitoring
-- https://neptune.ai/blog/llm-observability
+- https://web.archive.org/web/20251005112019/https://neptune.ai/blog/llm-observability
 - https://www.qwak.com/post/prompt-management
 - https://humanloop.com/blog/human-in-the-loop-ai
 - https://www.projectpro.io/article/llm-parameters/1029


### PR DESCRIPTION
neptune.ai was acquired by OpenAI in December 2025 and the entire blog now 308-redirects to a press-release page, so the neptune.ai/blog link(s) below no longer lead to the referenced article(s).

This PR fixes 1 dead link in `topics/llm/logs-pillar.md`, pointing it to the Wayback Machine snapshot of the original article.
All archive links are pinned to the last working (HTTP 200) Wayback capture before the redirect took effect.